### PR TITLE
Feat: add LoongArch build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=ppc64 go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o pty_linux_ppc64
           CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o pty_linux_ppc64le
           CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o pty_linux_riscv64
+          CGO_ENABLED=0 GOOS=linux GOARCH=loong64 go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o pty_linux_loong64
           CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o pty_linux_s390x
           CGO_ENABLED=0 GOOS=netbsd GOARCH=386 go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o pty_netbsd_386
           CGO_ENABLED=0 GOOS=netbsd GOARCH=amd64 go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o pty_netbsd_x64
@@ -65,6 +66,7 @@ jobs:
             pty_linux_ppc64
             pty_linux_ppc64le
             pty_linux_riscv64
+            pty_linux_loong64
             pty_linux_s390x
             pty_netbsd_386
             pty_netbsd_x64


### PR DESCRIPTION
# Brief
Add LoongArch build task to the github CI workflow.
It works fine on my machine, with Loongson 3B6000 and AOSC OS.
# Screenshot
<img width="1882" height="1773" alt="QQ20260314-185151" src="https://github.com/user-attachments/assets/a87d196d-fc29-4048-a95f-bb938aa7c97b" />
